### PR TITLE
Add expand as $-prefixed key

### DIFF
--- a/AzurePipelinesPS/Private/Set-APQueryParameters.ps1
+++ b/AzurePipelinesPS/Private/Set-APQueryParameters.ps1
@@ -69,7 +69,7 @@ function Set-APQueryParameters
             {
                 Continue
             }
-            ElseIf ($key -eq 'Top')
+            ElseIf ($key -eq 'Top', 'Expand')
             {
                 "`$$key=$($InputObject.$key)"
             }

--- a/AzurePipelinesPS/Private/Set-APQueryParameters.ps1
+++ b/AzurePipelinesPS/Private/Set-APQueryParameters.ps1
@@ -1,5 +1,5 @@
 function Set-APQueryParameters
-{    
+{
     <#
     .SYNOPSIS
 
@@ -10,7 +10,7 @@ function Set-APQueryParameters
     Returns the formated query parameter string.
 
     .PARAMETER InputObject
-    
+
     The PS bound parameters.
 
     .OUTPUTS
@@ -52,12 +52,12 @@ function Set-APQueryParameters
             'Verbose'
             'Debug'
             'ErrorAction'
-            'WarningAction' 
-            'InformationAction' 
-            'ErrorVariable' 
-            'WarningVariable' 
-            'InformationVariable' 
-            'OutVariable' 
+            'WarningAction'
+            'InformationAction'
+            'ErrorVariable'
+            'WarningVariable'
+            'InformationVariable'
+            'OutVariable'
             'OutBuffer'
             'UserDescriptor'
             'GroupDescriptor'
@@ -69,11 +69,7 @@ function Set-APQueryParameters
             {
                 Continue
             }
-            ElseIf ($key -eq 'Top', 'Expand')
-            {
-                "`$$key=$($InputObject.$key)"
-            }
-            ElseIf ($key -eq 'Mine')
+            ElseIf ($key -in 'Top', 'Expand', 'Mine')
             {
                 "`$$key=$($InputObject.$key)"
             }
@@ -88,7 +84,7 @@ function Set-APQueryParameters
             }
             else
             {
-                "$key=$($InputObject.$key)"                    
+                "$key=$($InputObject.$key)"
             }
         }
         Return ($queryParams -join '&')

--- a/AzurePipelinesPS/Tests/Set-APQueryParameters.Tests.ps1
+++ b/AzurePipelinesPS/Tests/Set-APQueryParameters.Tests.ps1
@@ -1,0 +1,20 @@
+$Script:ModuleName = 'AzurePipelinesPS'
+$Script:ModuleRoot = Split-Path -Path $PSScriptRoot -Parent
+$Script:ModuleManifestPath = "$ModuleRoot\..\Output\$ModuleName\$ModuleName.psd1"
+$Script:TestDataPath = "TestDrive:\ModuleData.json"
+Import-Module $ModuleManifestPath -Force
+InModuleScope $ModuleName {
+    #region testParams
+    $Function = 'Set-APQueryParameters'
+    #endregion testParams
+
+    Describe "Function: [$Function]" {
+        Context '$-prefixed query parameters' {
+            'Mine', 'Top', 'Expand' | ForEach-Object {
+                It "${_} should be converted to `$${_}" {
+                    &$Function -InputObject @{$_ = 'value'} | Should -Be "`$${_}=value"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Based on documentation, expand query key should have $-prefix: https://docs.microsoft.com/en-us/rest/api/azure/devops/release/definitions/list?view=azure-devops-rest-5.0