### PR TITLE
Fixed Unprotect-APSecurePersonalAccessToken Linux compatibility

### DIFF
--- a/AzurePipelinesPS/Private/Unprotect-APSecurePersonalAccessToken.ps1
+++ b/AzurePipelinesPS/Private/Unprotect-APSecurePersonalAccessToken.ps1
@@ -41,6 +41,11 @@ Function Unprotect-APSecurePersonalAccessToken
     {
         $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($PersonalAccessToken)
         $plainText = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
+
+        if ([environment]::OSVersion.Platform -eq "Unix") {
+            $plainText = [System.Net.NetworkCredential]::new("", $PersonalAccessToken).Password
+        }
+
         return $plainText
     }
 }


### PR DESCRIPTION
On Linux version of PowerShell Core this one print just first character ( **E** ):
```powershell
$PersonalAccessToken = ConvertTo-SecureString -AsPlainText "Example PAT" -Force
$BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($PersonalAccessToken)
$plainText = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
Write-Host $plainText
```

My alternative methods should works on all PowerShell versions afaik but for maximum safety I included platform check so new logic only applies to Linux nodes.