### PR TITLE
Fixed X-MS-ContinuationToken handling on PowerShell Core

### DIFF
--- a/AzurePipelinesPS/Public/Invoke-APWebRequest.ps1
+++ b/AzurePipelinesPS/Public/Invoke-APWebRequest.ps1
@@ -149,16 +149,24 @@ function Invoke-APWebRequest
                 
                     If ($content.value)
                     {
+                        $continuationToken = $results.Headers.'X-MS-ContinuationToken'
+                        if ($continuationToken -is [array]) {
+                            $continuationToken = $continuationToken[0]
+                        }
                         return @{
-                            continuationToken = $results.Headers.'X-MS-ContinuationToken'
+                            continuationToken = $continuationToken
                             count             = $content.count
                             value             = $content.value
                         }
                     }
                     else
                     {
+                        $continuationToken = $results.Headers.'X-MS-ContinuationToken'
+                        if ($continuationToken -is [array]) {
+                            $continuationToken = $continuationToken[0]
+                        }
                         return @{
-                            continuationToken = $results.Headers.'X-MS-ContinuationToken'
+                            continuationToken = $continuationToken
                             value             = $content
                         }
                     }


### PR DESCRIPTION
It looks to be that on PowerShell Core (at least on version 7.1.3 which I'm using) `$results.Headers.'X-MS-ContinuationToken'` value looks to be string array when on "old" PowerShell it is string.

That why example `Get-APUserList` failed to this error on PowerShell Core:
```
Cannot process argument transformation on parameter 'ContinuationToken'. Cannot convert value to type System.String.
```

This PR adds needed logic on way that it works on both.